### PR TITLE
feat: supporting 'pint' linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ The `obsctl-reloader-rules-checker` tool relies on the following command line to
   It is used to check that input files really store `PrometheusRule` objects; the tool is also used to run the rules unittests.
 - [`yamllint`](https://github.com/adrienverge/yamllint): this tool is a linter (so a nice to have) used both on the rules and the unittests.  
   It only need to be present if you plan on using the `-y` flag of `obsctl-reloader-rules-checker`.
+- [`pint`](https://github.com/cloudflare/pint/tree/main): this tool is an other linter which is aimed a tackling `PrometheusRule` objects.  
+  Again installing it is optional as its use is conditioned by the `-p` flag.
+
 
 You have to make sure that those tool are present on your computer when using the `obsctl-reloader-rules-checker` tool binary.
 
 Take a look at the following files to know the versions of those tools to use:
-- For `promtool`: [`hack/install-go-tools.sh`](./hack/install-go-tools.sh)
+- For `promtool` & `pint`: [`hack/install-go-tools.sh`](./hack/install-go-tools.sh)
 - For `yamllint`: [`hack/install-yamllint-tool.sh`](./hack/install-yamllint-tool.sh)
 
 ## Using the tool docker image instead
@@ -31,7 +34,7 @@ A docker image wrapping the tool is delivered on [quay](https://quay.io/reposito
 quay.io/rhobs/obsctl-reloader-rules-checker:latest
 ```
 
-**This is actually the preferred way of using the tool as the image contains the `promtool` and `yamllint` dependencies.**
+**This is actually the preferred way of using the tool as the image contains the `promtool`, `pint` and `yamllint` dependencies.**
 
 The only prerequisite before using the docker image is to have a container engine (`docker`, `podman`) installed on your computer.
 
@@ -43,7 +46,7 @@ The [`obsctl-reloader-rules-checker`](./obsctl-reloader-rules-checker) file at t
 
 It accepts the exact same arguments than the tool binary and make sure that:
 - The wrapped tool binary is built
-- `promtool` and `yamllint` are installed
+- `promtool`, `pint` and `yamllint` are installed
 
 This allows using the tool out of the box without understanding how to build or locally work on it (see [local developement](#local-developement)).
 However this script is not standalone and you have to clone the repository to use it.
@@ -108,6 +111,7 @@ Once again, the `-h` / `--help` flag is pretty explicit about those checks. Here
 - Check that the objects names and `tenant` label are properly set.
 - Run all the unittests with `promtool test rules`.
 - Run `yamllint` on the rule files and the unittests.
+- Run `pint` on the `spec` part of the `PrometheusRule` objects.
 
 ## Building the tool binary
 
@@ -122,7 +126,7 @@ To build the binary you just have to run:
 make build
 ```
 
-The binary will be delivered in the `bin` folder. `promtool` is also built and installed when running that command.
+The binary will be delivered in the `bin` folder. `promtool` & `pint` are also built and installed when running that command.
 
 ## Building the tool docker image
 
@@ -177,7 +181,7 @@ The difference between the 2 commands are that:
 ```
 make clean
 ```
-This will remove the `bin` folder in which the tool binary has been delivered but also the `.bingo` folder which was used to build `promtool`.
+This will remove the `bin` folder in which the tool binary has been delivered but also the `.bingo` folder which was used to build `promtool` & `pint`.
 
 ## Delivering the code
 

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -12,4 +12,5 @@ cd "$(dirname $BASH_SOURCE)/.."
 go install -mod=readonly github.com/bwplotka/bingo@latest
 
 unset GOFLAGS
-bingo get --v -l github.com/prometheus/prometheus/cmd/promtool@v0.41.0
+bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.41.0
+bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1

--- a/main.go
+++ b/main.go
@@ -72,7 +72,23 @@ type testObj struct {
 
 var errSkipped = errors.New("unexpected error: skipped file not detected as skipped")
 
-func visitDir(dirPath string, isLogging bool, callBack func(bool, string) error) {
+func wrapWithLogging(callBack func(bool, string) error) func(bool, string) error {
+	return func(isDir bool, path string) error {
+		err := callBack(isDir, path)
+
+		if errors.Is(err, errSkipped) {
+			if !isDir {
+				log.Infof("[%s] skipped!\n", path)
+			}
+		} else if err == nil {
+			log.Infof("[%s] done\n", path)
+		}
+
+		return err
+	}
+}
+
+func visitDir(dirPath string, callBack func(bool, string) error) {
 	gitDirPath := filepath.Join(dirPath, ".git")
 
 	err := filepath.WalkDir(dirPath, func(path string, dirEntry fs.DirEntry, err error) error {
@@ -88,15 +104,7 @@ func visitDir(dirPath string, isLogging bool, callBack func(bool, string) error)
 
 		err = callBack(isDir, path)
 
-		if errors.Is(err, errSkipped) {
-			if isLogging && !isDir {
-				log.Infof("[%s] skipped!\n", path)
-			}
-		} else if err == nil {
-			if isLogging {
-				log.Infof("[%s] done\n", path)
-			}
-		} else {
+		if err != nil && !errors.Is(err, errSkipped) {
 			log.Fatalf("[%s] %s\n", path, err.Error())
 		}
 
@@ -127,7 +135,7 @@ func isNamedAsARuleFile(path string) bool {
 	return (strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")) && !isNamedAsAUnitTest(path)
 }
 
-func loadPrometheusRule(ruleFilePath string) (*genericObj, error) {
+func loadYamlAsPrometheusRule(ruleFilePath string) (*genericObj, error) {
 	fileContent, err := os.ReadFile(filepath.Clean(ruleFilePath))
 
 	if err != nil {
@@ -208,110 +216,128 @@ func checkToolIsInstalled(tool string) {
 	}
 }
 
-func checkRule(ruleFilePath, tenant, tempDirPath string, objNameToFilePath *map[string]string, groupNameToFilePath *map[string]string) error {
-	obj, err := loadPrometheusRule(ruleFilePath)
-
-	if err != nil {
-		return err
-	}
-
-	objName := obj.Metadata.Name
-
-	if otherFilePath, isAlreadyUsed := (*objNameToFilePath)[objName]; isAlreadyUsed {
-		return fmt.Errorf("value for 'metadata.name' attribute is reused (there is already a 'PrometheusRule' named '%s' in '%s' file)", objName, otherFilePath)
-	}
-	(*objNameToFilePath)[objName] = ruleFilePath
-
-	if !objectNameRegexp.MatchString(objName) {
-		return fmt.Errorf("'metadata.name' attribute does not match pattern '%s' (value is '%s')", objectNamePattern, objName)
-	}
-
-	if tenant != "" && !strings.HasPrefix(objName, tenant+"-") {
-		return fmt.Errorf("'metadata.name' attribute does not starts with '%s-' (value is '%s')", tenant, objName)
-	}
-
-	objTenant := obj.Metadata.Labels.Tenant
-	if objTenant != tenant {
-		if tenant == "" {
-			return fmt.Errorf("'metadata.labels.tenant' attribute is set while it shouldn't (value is '%s')", objTenant)
+func wrapWithRuleFileNameChecks(isSkippingUnexpectedFiles bool, callback func(string) error) func(bool, string) error {
+	return func(isDir bool, path string) error {
+		if isDir {
+			if isSkippingUnexpectedFiles {
+				return errSkipped
+			}
+			return errors.New("subdirectories are not allowed when not generating a template (see --rules-dir flag)")
 		}
-		return fmt.Errorf("'metadata.labels.tenant' attribute is not set to '%s' (value is '%s')", tenant, objTenant)
+
+		if !isNamedAsARuleFile(path) {
+			if isSkippingUnexpectedFiles {
+				return errSkipped
+			}
+			return errors.New("file is not named as a rule file (see --rules-dir flag)")
+		}
+
+		return callback(path)
 	}
+}
 
-	specFilePath := filepath.Join(tempDirPath, filepath.Base(ruleFilePath))
+func wrapWithTestFileNameChecks(callback func(string) error) func(bool, string) error {
+	return func(isDir bool, path string) error {
+		if isDir || !isNamedAsAUnitTest(path) {
+			return errSkipped
+		}
 
-	if err := storeAsYaml(&obj.Spec, specFilePath); err != nil {
-		return fmt.Errorf("unexpected error: %w", err)
+		return callback(path)
 	}
+}
 
-	if output, err := runAndOutputCommand("promtool", "check", "rules", specFilePath); err != nil {
-		return fmt.Errorf("failed to run 'promtool check rules' on the 'spec' part of the file; output:\n%v", output)
-	}
+func wrapWithRulePreChecks(callBack func(string, *genericObj, string) error) func(string) error {
+	return func(ruleFilePath string) error {
+		obj, err := loadYamlAsPrometheusRule(ruleFilePath)
 
-	{
-		var ruleGroupsObj ruleGroupsObj
+		if err != nil {
+			return err
+		}
 
-		if err := obj.Spec.Decode(&ruleGroupsObj); err != nil {
+		tempDirPath, err := os.MkdirTemp("", "obsctl-reloader-rules-checker")
+		if err != nil {
+			log.Fatalf("unable to create a temporary directory: %v\n", err)
+		}
+
+		defer os.RemoveAll(tempDirPath)
+
+		specFilePath := filepath.Join(tempDirPath, filepath.Base(ruleFilePath))
+
+		if err := storeAsYaml(&obj.Spec, specFilePath); err != nil {
 			return fmt.Errorf("unexpected error: %w", err)
 		}
 
-		for _, ruleGroupNode := range ruleGroupsObj.Groups {
-			var ruleGroupObj ruleGroupObj
-
-			if err := ruleGroupNode.Decode(&ruleGroupObj); err != nil {
-				return fmt.Errorf("unexpected error: %w", err)
-			}
-
-			if otherGroupFilePath, isAlreadyUsed := (*groupNameToFilePath)[ruleGroupObj.Name]; isAlreadyUsed {
-				return fmt.Errorf("value for 'spec.groups[].name' attribute is reused (there is already a group named '%s' in '%s' file)", ruleGroupObj.Name, otherGroupFilePath)
-			}
-			(*groupNameToFilePath)[ruleGroupObj.Name] = ruleFilePath
-
-			// This check is needed because RHOBS servers are running a very old version of Prometheus code in which the interval at this level was mandatory at the time.
-			// 'promtool check rules' is parsing the rules with a newer version of Prometheus in which specifying the interval at this level is now optional.
-			if ruleGroupObj.Interval == "" {
-				return fmt.Errorf("attribute 'spec.groups[].interval' is missing for some group named '%s'", ruleGroupObj.Name)
-			}
-		}
+		return callBack(ruleFilePath, obj, specFilePath)
 	}
-
-	return nil
 }
 
 func checkRules(rulesDirPath, tenant string, isGeneratingTemplate bool) {
 	log.Infoln("checking rules...")
 
-	tempDirPath, err := os.MkdirTemp("", "obsctl-reloader-checking-rules-temp-dir")
-	if err != nil {
-		log.Fatalf("unable to create a temporary directory: %v\n", err)
-	}
-
-	defer os.RemoveAll(tempDirPath)
-
 	objNameToFilePath := make(map[string]string)
 	groupNameToFilePath := make(map[string]string)
 
-	visitDir(rulesDirPath, true,
-		func(isDir bool, path string) error {
-			if isDir {
-				if isGeneratingTemplate {
-					return errSkipped
-				}
-				return errors.New("subdirectories are not allowed when not generating a template (see --rules-dir flag)")
+	visitDir(rulesDirPath, wrapWithLogging(wrapWithRuleFileNameChecks(isGeneratingTemplate, wrapWithRulePreChecks(
+		func(ruleFilePath string, obj *genericObj, specFilePath string) error {
+			objName := obj.Metadata.Name
+
+			if otherFilePath, isAlreadyUsed := objNameToFilePath[objName]; isAlreadyUsed {
+				return fmt.Errorf("value for 'metadata.name' attribute is reused (there is already a 'PrometheusRule' named '%s' in '%s' file)", objName, otherFilePath)
+			}
+			objNameToFilePath[objName] = ruleFilePath
+
+			if !objectNameRegexp.MatchString(objName) {
+				return fmt.Errorf("'metadata.name' attribute does not match pattern '%s' (value is '%s')", objectNamePattern, objName)
 			}
 
-			if !isNamedAsARuleFile(path) {
-				if isGeneratingTemplate {
-					return errSkipped
-				}
-				return errors.New("file is not named as a rule file (see --rules-dir flag)")
+			if tenant != "" && !strings.HasPrefix(objName, tenant+"-") {
+				return fmt.Errorf("'metadata.name' attribute does not starts with '%s-' (value is '%s')", tenant, objName)
 			}
 
-			return checkRule(path, tenant, tempDirPath, &objNameToFilePath, &groupNameToFilePath)
-		})
+			objTenant := obj.Metadata.Labels.Tenant
+			if objTenant != tenant {
+				if tenant == "" {
+					return fmt.Errorf("'metadata.labels.tenant' attribute is set while it shouldn't (value is '%s')", objTenant)
+				}
+				return fmt.Errorf("'metadata.labels.tenant' attribute is not set to '%s' (value is '%s')", tenant, objTenant)
+			}
+
+			if output, err := runAndOutputCommand("promtool", "check", "rules", specFilePath); err != nil {
+				return fmt.Errorf("failed to run 'promtool check rules' on the 'spec' part of the file; output:\n%v", output)
+			}
+
+			{
+				var ruleGroupsObj ruleGroupsObj
+
+				if err := obj.Spec.Decode(&ruleGroupsObj); err != nil {
+					return fmt.Errorf("unexpected error: %w", err)
+				}
+
+				for _, ruleGroupNode := range ruleGroupsObj.Groups {
+					var ruleGroupObj ruleGroupObj
+
+					if err := ruleGroupNode.Decode(&ruleGroupObj); err != nil {
+						return fmt.Errorf("unexpected error: %w", err)
+					}
+
+					if otherGroupFilePath, isAlreadyUsed := groupNameToFilePath[ruleGroupObj.Name]; isAlreadyUsed {
+						return fmt.Errorf("value for 'spec.groups[].name' attribute is reused (there is already a group named '%s' in '%s' file)", ruleGroupObj.Name, otherGroupFilePath)
+					}
+					groupNameToFilePath[ruleGroupObj.Name] = ruleFilePath
+
+					// This check is needed because RHOBS servers are running a very old version of Prometheus code in which the interval at this level was mandatory at the time.
+					// 'promtool check rules' is parsing the rules with a newer version of Prometheus in which specifying the interval at this level is now optional.
+					if ruleGroupObj.Interval == "" {
+						return fmt.Errorf("attribute 'spec.groups[].interval' is missing for some group named '%s'", ruleGroupObj.Name)
+					}
+				}
+			}
+
+			return nil
+		}))))
 }
 
-func lintFile(filePath string) error {
+func runYamlLintOnFile(filePath string) error {
 	if output, err := runAndOutputCommand("yamllint", filePath); err != nil {
 		return fmt.Errorf("failed to run 'yamllint'; output:\n%v", output)
 	}
@@ -319,28 +345,27 @@ func lintFile(filePath string) error {
 	return nil
 }
 
-func lintFiles(rulesDirPath, testsDirPath string) {
+func runYamlLint(rulesDirPath, testsDirPath string) {
 	log.Infoln("running YAML linter...")
 
-	visitDir(rulesDirPath, true,
-		func(isDir bool, path string) error {
-			if isDir || !isNamedAsARuleFile(path) {
-				return errSkipped
-			}
-
-			return lintFile(path)
-		})
+	visitDir(rulesDirPath, wrapWithLogging(wrapWithRuleFileNameChecks(true, runYamlLintOnFile)))
 
 	if testsDirPath != "" {
-		visitDir(testsDirPath, true,
-			func(isDir bool, path string) error {
-				if isDir || !isNamedAsAUnitTest(path) {
-					return errSkipped
-				}
-
-				return lintFile(path)
-			})
+		visitDir(testsDirPath, wrapWithLogging(wrapWithTestFileNameChecks(runYamlLintOnFile)))
 	}
+}
+
+func runPint(rulesDirPath string) {
+	log.Infoln("running 'pint' linter...")
+
+	visitDir(rulesDirPath, wrapWithLogging(wrapWithRuleFileNameChecks(true, wrapWithRulePreChecks(
+		func(ruleFilePath string, obj *genericObj, specFilePath string) error {
+			if output, err := runAndOutputCommand("pint", "lint", specFilePath); err != nil {
+				return fmt.Errorf("failed to run 'pint'; output:\n%v", output)
+			}
+
+			return nil
+		}))))
 }
 
 const templateHeaderFormat = `
@@ -389,13 +414,13 @@ func generateTemplate(rulesDirPath, tenant, templatePath string) {
 		},
 	}
 
-	visitDir(rulesDirPath, false,
+	visitDir(rulesDirPath,
 		func(isDir bool, path string) error {
 			if isDir || !isNamedAsARuleFile(path) {
 				return errSkipped
 			}
 
-			obj, err := loadPrometheusRule(path)
+			obj, err := loadYamlAsPrometheusRule(path)
 
 			if err != nil {
 				return err
@@ -478,78 +503,70 @@ func checkTemplateIsCommitted(templatePath string) {
 	}
 }
 
-func runTest(testPath, rulesDirPath string) error {
-	testContent, err := os.ReadFile(filepath.Clean(testPath))
-
-	if err != nil {
-		return err
-	}
-
-	var testObj testObj
-
-	if err := yaml.Unmarshal(testContent, &testObj); err != nil {
-		return fmt.Errorf("does not store unit test serialized in YAML: %w", err)
-	}
-
-	tempDirPath, err := os.MkdirTemp("", "obsctl-reloader-run-test-temp-dir")
-	if err != nil {
-		return fmt.Errorf("unable to create a temporary directory: %w", err)
-	}
-
-	defer os.RemoveAll(tempDirPath)
-
-	for _, ruleFileRelPath := range testObj.RuleFiles {
-		if !isNamedAsARuleFile(ruleFileRelPath) {
-			return fmt.Errorf("'%s' file listed by the 'rule_file' attribute is not named as a rule file (see --rules-dir flag)", ruleFileRelPath)
-		}
-
-		ruleFilePath := filepath.Join(rulesDirPath, ruleFileRelPath)
-
-		if _, err := os.Stat(ruleFilePath); err != nil {
-			return fmt.Errorf("'%s' file listed by the 'rule_file' attribute does not locate an existing file in '%s' (--rules-dir flag): %w", ruleFileRelPath, rulesDirPath, err)
-		}
-
-		ruleObj, err := loadPrometheusRule(ruleFilePath)
-
-		if err != nil {
-			return fmt.Errorf("unexpected error: %w", err)
-		}
-
-		ruleFileTempPath := filepath.Join(tempDirPath, ruleFileRelPath)
-
-		if err := os.MkdirAll(filepath.Dir(ruleFileTempPath), 0700); err != nil {
-			return fmt.Errorf("unexpected error: %w", err)
-		}
-
-		if err := storeAsYaml(&ruleObj.Spec, ruleFileTempPath); err != nil {
-			return fmt.Errorf("unexpected error: %w", err)
-		}
-	}
-
-	testTempPath := filepath.Join(tempDirPath, filepath.Base(testPath))
-
-	if err := os.WriteFile(testTempPath, testContent, 0600); err != nil {
-		return fmt.Errorf("unexpected error: %w", err)
-	}
-
-	if output, err := runAndOutputCommand("promtool", "test", "rules", testTempPath); err != nil {
-		return fmt.Errorf("failed to run 'promtool test rules'; output:\n%v", output)
-	}
-
-	return nil
-}
-
 func runTests(testsDirPath, rulesDirPath string) {
 	log.Infoln("running the unit tests...")
 
-	visitDir(testsDirPath, true,
-		func(isDir bool, path string) error {
-			if isDir || !isNamedAsAUnitTest(path) {
-				return errSkipped
+	visitDir(testsDirPath, wrapWithLogging(wrapWithTestFileNameChecks(
+		func(testPath string) error {
+			testContent, err := os.ReadFile(filepath.Clean(testPath))
+
+			if err != nil {
+				return err
 			}
 
-			return runTest(path, rulesDirPath)
-		})
+			var testObj testObj
+
+			if err := yaml.Unmarshal(testContent, &testObj); err != nil {
+				return fmt.Errorf("does not store unit test serialized in YAML: %w", err)
+			}
+
+			tempDirPath, err := os.MkdirTemp("", "obsctl-reloader-rules-checker")
+			if err != nil {
+				return fmt.Errorf("unable to create a temporary directory: %w", err)
+			}
+
+			defer os.RemoveAll(tempDirPath)
+
+			for _, ruleFileRelPath := range testObj.RuleFiles {
+				if !isNamedAsARuleFile(ruleFileRelPath) {
+					return fmt.Errorf("'%s' file listed by the 'rule_file' attribute is not named as a rule file (see --rules-dir flag)", ruleFileRelPath)
+				}
+
+				ruleFilePath := filepath.Join(rulesDirPath, ruleFileRelPath)
+
+				if _, err := os.Stat(ruleFilePath); err != nil {
+					return fmt.Errorf("'%s' file listed by the 'rule_file' attribute does not locate an existing file in '%s' (--rules-dir flag): %w", ruleFileRelPath, rulesDirPath, err)
+				}
+
+				ruleObj, err := loadYamlAsPrometheusRule(ruleFilePath)
+
+				if err != nil {
+					return fmt.Errorf("unexpected error: %w", err)
+				}
+
+				ruleFileTempPath := filepath.Join(tempDirPath, ruleFileRelPath)
+
+				if err := os.MkdirAll(filepath.Dir(ruleFileTempPath), 0700); err != nil {
+					return fmt.Errorf("unexpected error: %w", err)
+				}
+
+				if err := storeAsYaml(&ruleObj.Spec, ruleFileTempPath); err != nil {
+					return fmt.Errorf("unexpected error: %w", err)
+				}
+			}
+
+			testTempPath := filepath.Join(tempDirPath, filepath.Base(testPath))
+
+			if err := os.WriteFile(testTempPath, testContent, 0600); err != nil {
+				return fmt.Errorf("unexpected error: %w", err)
+			}
+
+			if output, err := runAndOutputCommand("promtool", "test", "rules", testTempPath); err != nil {
+				return fmt.Errorf("failed to run 'promtool test rules'; output:\n%v", output)
+			}
+
+			return nil
+		})))
 }
 
 const longDesc = `Perform the following checks on the rules to make sure that they can be consumed by obsctl-reloader:
@@ -575,13 +592,13 @@ const longDesc = `Perform the following checks on the rules to make sure that th
 - Run the unit tests in the location given by the --tests-dir flag with 'promtool test rules'.
   Some adapation is made to let the 'rule_files' attribute list the paths of 'PrometheusRule' files in (and relative to) the rules directory (--rules-dir flag).
 
-- Eventually run the YAML linter on all the rule files and the unit tests if --yaml-lint flag is set.
+- Eventually run linters on all the rule files and eventually on the unit tests.
 
 You can learn more on obsctl-reloader there:
 https://github.com/rhobs/obsctl-reloader
 
 Be sure 'promtool' is installed prior running this tool or it will fail.
-Similarly make sure 'yamllint' if installed when using the --yaml-lint flag.`
+Similarly make sure 'yamllint' or 'pint' are installed when using the linter flags.`
 
 const rulesDirFlagDesc = `path to the directory containing the rule files
   Only '.yaml' and '.yml' suffixed files are considered as rule files.
@@ -597,6 +614,7 @@ const rulesDirFlagDesc = `path to the directory containing the rule files
 const tenantFlagDesc = `the tenant targeted by the given rules
   Flag is mandatory unless --gen-template is set in which case it is optional.`
 const yamlLintFlagDesc = "run 'yamllint' on the rule files and the unit tests"
+const pintFlagDesc = "run 'pint' on the 'spec' part of the rule files"
 const genTemplateFlagDesc = "path to the template to generate"
 const noUncommittedTemplateFlagDesc = `fails if the generated template is not committed
   Typically used by the build system to ensure that the template is part of a commit.
@@ -610,7 +628,7 @@ const testsDirFlagDesc = `path to the directory containing the promtool unit tes
 
 func main() {
 	var rulesDirPath, givenTenant, expectedRulesTenant, templatePath, testsDirPath string
-	var isRunningLinter, isExpectingCommittedTemplate bool
+	var isRunningYamlLint, isRunningPint, isExpectingCommittedTemplate bool
 
 	rootCmd := &cobra.Command{
 		Use:     filepath.Base(os.Args[0]),
@@ -662,14 +680,18 @@ func main() {
 			}
 
 			checkToolIsInstalled("promtool")
-			if isRunningLinter {
+			if isRunningYamlLint {
 				checkToolIsInstalled("yamllint")
 			}
 
 			checkRules(rulesDirPath, expectedRulesTenant, templatePath != "")
 
-			if isRunningLinter {
-				lintFiles(rulesDirPath, testsDirPath)
+			if isRunningYamlLint {
+				runYamlLint(rulesDirPath, testsDirPath)
+			}
+
+			if isRunningPint {
+				runPint(rulesDirPath)
 			}
 
 			if templatePath != "" {
@@ -688,10 +710,11 @@ func main() {
 
 	rootCmd.Flags().StringVarP(&rulesDirPath, "rules-dir", "d", "", rulesDirFlagDesc)
 	rootCmd.Flags().StringVarP(&givenTenant, "tenant", "t", "", tenantFlagDesc)
-	rootCmd.Flags().BoolVarP(&isRunningLinter, "yaml-lint", "y", false, yamlLintFlagDesc)
+	rootCmd.Flags().BoolVarP(&isRunningYamlLint, "yaml-lint", "y", false, yamlLintFlagDesc)
+	rootCmd.Flags().BoolVarP(&isRunningPint, "pint", "p", false, pintFlagDesc)
 	rootCmd.Flags().StringVarP(&templatePath, "gen-template", "g", "", genTemplateFlagDesc)
 	rootCmd.Flags().BoolVar(&isExpectingCommittedTemplate, "no-uncommitted-template", false, noUncommittedTemplateFlagDesc)
-	rootCmd.Flags().StringVar(&testsDirPath, "tests-dir", "", testsDirFlagDesc)
+	rootCmd.Flags().StringVarP(&testsDirPath, "tests-dir", "T", "", testsDirFlagDesc)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This linter is used in the repository used for the `rhtap` RHOBS tenant:
https://github.com/avi-biton/o11y/tree/main

It provides some interesting checks.