### PR TITLE
Install and run po-linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 WORKDIR /work
 

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -9,12 +9,10 @@ fi
 
 cd "$(dirname $BASH_SOURCE)/.."
 
-go install -mod=readonly github.com/bwplotka/bingo@latest
-
 # The following PR has been merged in bingo:
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands
 unset GOFLAGS
 bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.48.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
-go install -mod=readonly github.com/prometheus-operator/prometheus-operator/cmd/po-lint
+go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -9,11 +9,12 @@ fi
 
 cd "$(dirname $BASH_SOURCE)/.."
 
-go install github.com/bwplotka/bingo@latest
+go install -mod=readonly github.com/bwplotka/bingo@latest
 
 # The following PR has been merged in bingo:
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands
+unset GOFLAGS
 bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.48.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
-go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint
+go install -mod=readonly github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -15,6 +15,6 @@ go install -mod=readonly github.com/bwplotka/bingo@latest
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands
 unset GOFLAGS
-bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.46.0
+bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.48.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
-#go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint
+go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -17,4 +17,4 @@ go install -mod=readonly github.com/bwplotka/bingo@latest
 unset GOFLAGS
 bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.46.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
-go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint
+#go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -17,3 +17,4 @@ go install -mod=readonly github.com/bwplotka/bingo@latest
 unset GOFLAGS
 bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.46.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
+go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -9,12 +9,28 @@ fi
 
 cd "$(dirname $BASH_SOURCE)/.."
 
+# System info in lower case to avoid issues.
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+OS_ARCH="${OS}-${ARCH}"
+
+PROMETHEUS_VERSION="v2.48.0"
+
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'prometheus')
+PROMETHEUS_DEST="/tmp/prometheus"
+mkdir -p $PROMETHEUS_DEST
+RELEASE_INFO=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/tags/$PROMETHEUS_VERSION)
+FILENAME=$(echo -E "$RELEASE_INFO" | jq -r --arg os_arch "$OS_ARCH" '.assets[] | select(.name | contains($os_arch)) | .name')
+FILENAME_WITHOUT_EXTENSION="${FILENAME%.*.*}"
+DOWNLOAD_URL=$(echo -E "$RELEASE_INFO" | jq -r --arg os_arch "$OS_ARCH" '.assets[] | select(.name | contains($os_arch)) | .browser_download_url')
+(cd "$TMPDIR" && wget "$DOWNLOAD_URL" && tar -xzf "$FILENAME" && mv "$FILENAME_WITHOUT_EXTENSION"/promtool ${PROMETHEUS_DEST})
+rm -rf "$TMPDIR"
+
 go install -mod=readonly github.com/bwplotka/bingo@latest
 
 # The following PR has been merged in bingo:
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands
 unset GOFLAGS
-bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.48.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
 go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -9,6 +9,8 @@ fi
 
 cd "$(dirname $BASH_SOURCE)/.."
 
+go install -mod=readonly github.com/bwplotka/bingo@latest
+
 # The following PR has been merged in bingo:
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -17,8 +17,7 @@ OS_ARCH="${OS}-${ARCH}"
 PROMETHEUS_VERSION="v2.48.0"
 
 TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'prometheus')
-PROMETHEUS_DEST="/tmp/prometheus"
-mkdir -p $PROMETHEUS_DEST
+PROMETHEUS_DEST="$(go env GOPATH)/bin"
 RELEASE_INFO=$(curl -s https://api.github.com/repos/prometheus/prometheus/releases/tags/$PROMETHEUS_VERSION)
 FILENAME=$(echo -E "$RELEASE_INFO" | jq -r --arg os_arch "$OS_ARCH" '.assets[] | select(.name | contains($os_arch)) | .name')
 FILENAME_WITHOUT_EXTENSION="${FILENAME%.*.*}"

--- a/hack/install-go-tools.sh
+++ b/hack/install-go-tools.sh
@@ -9,12 +9,11 @@ fi
 
 cd "$(dirname $BASH_SOURCE)/.."
 
-go install -mod=readonly github.com/bwplotka/bingo@latest
+go install github.com/bwplotka/bingo@latest
 
 # The following PR has been merged in bingo:
 # https://github.com/bwplotka/bingo/pull/142
 # Once the new bingo version is released, make sure to append '-t 0' in below commands
-unset GOFLAGS
 bingo get -v -l github.com/prometheus/prometheus/cmd/promtool@v0.48.0
 bingo get -v -l github.com/cloudflare/pint/cmd/pint@v0.44.1
 go install github.com/prometheus-operator/prometheus-operator/cmd/po-lint

--- a/main.go
+++ b/main.go
@@ -306,6 +306,10 @@ func checkRules(rulesDirPath, tenant string, isGeneratingTemplate bool) {
 				return fmt.Errorf("failed to run 'promtool check rules' on the 'spec' part of the file; output:\n%v", output)
 			}
 
+			if output, err := runAndOutputCommand("po-lint", specFilePath); err != nil {
+				return fmt.Errorf("failed to run 'po-lint' on the file; output:\n%v", output)
+			}
+
 			{
 				var ruleGroupsObj ruleGroupsObj
 


### PR DESCRIPTION
`po-linter` is recommended in the Prometheus Operator repo for linting `PrometheusRule` CRDs (see https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/linting.md).

It detects problems that this tool so far has been letting pass, like rules with labels that aren't strings.